### PR TITLE
drop backend client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ovos-utils>=0.1.0
 ovos-bus-client>=0.0.9,<2.0.0
 ovos-workshop>=0.0.16,<4.0.0
-ovos-backend-client>=0.1.0,<2.0.0
 spotipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-utils>=0.1.0
+ovos-utils>=0.5.0
 ovos-bus-client>=0.0.9,<2.0.0
 ovos-workshop>=0.0.16,<4.0.0
 spotipy

--- a/spotify.py
+++ b/spotify.py
@@ -6,7 +6,7 @@ from typing import Tuple, Dict
 import requests
 import spotipy
 from ovos_backend_client.api import OAuthApi
-from ovos_backend_client.database import OAuthTokenDatabase, OAuthApplicationDatabase
+from ovos_utils.oauth import OAuthTokenDatabase, OAuthApplicationDatabase
 from ovos_utils.log import LOG
 from ovos_utils.parse import match_one, fuzzy_match, MatchStrategy
 from ovos_utils.xdg_utils import xdg_config_home

--- a/spotify.py
+++ b/spotify.py
@@ -5,8 +5,7 @@ from typing import Tuple, Dict
 
 import requests
 import spotipy
-from ovos_backend_client.api import OAuthApi
-from ovos_utils.oauth import OAuthTokenDatabase, OAuthApplicationDatabase
+from ovos_utils.oauth import OAuthTokenDatabase, OAuthApplicationDatabase, get_oauth_token
 from ovos_utils.log import LOG
 from ovos_utils.parse import match_one, fuzzy_match, MatchStrategy
 from ovos_utils.xdg_utils import xdg_config_home
@@ -47,8 +46,7 @@ class OVOSSpotifyCredentials(SpotifyAuthBase):
 
     @staticmethod
     def get_access_token():
-        t = OAuthApi().get_oauth_token(OAUTH_TOKEN_ID,
-                                       auto_refresh=True)
+        t = get_oauth_token(OAUTH_TOKEN_ID, auto_refresh=True)
         # TODO auto_refresh flag not working
         if OVOSSpotifyCredentials.is_token_expired(t):
             LOG.warning("SPOTIFY TOKEN EXPIRED")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the `ovos-backend-client` dependency from the requirements.
	- Added the `spotipy` dependency to the requirements.
	- Updated import paths for OAuth-related components in the Spotify integration.
	- Increased version requirement for `ovos-utils` to `>=0.5.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->